### PR TITLE
Bumping version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-angular-bootstrap-colorpicker",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "main": [
     "js/bootstrap-colorpicker-module.js",
     "css/colorpicker.css"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-angular-bootstrap-colorpicker",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "Native AngularJS colorpicker directive",
   "main": "js/bootstrap-colorpicker-module.js",
   "directories": {


### PR DESCRIPTION
- the latest `3.0.13` tag is pointing to the previous `3.0.13` tag that was deleted and doesn't include the latest fix. Needing to bump to an entirely new version so a tag of the same can be done.
